### PR TITLE
Fix for messed up images when presenting VC is landscape

### DIFF
--- a/Example/editorTest.xcodeproj/project.pbxproj
+++ b/Example/editorTest.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hamed.editorTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -371,6 +372,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hamed.editorTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Example/editorTest/Info.plist
+++ b/Example/editorTest/Info.plist
@@ -20,6 +20,12 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>This app requires access to the camera.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app does not require access to the microphone.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>This app requires access to the photo library.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -31,12 +37,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string>This app requires access to the camera.</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>This app does not require access to the microphone.</string>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>This app requires access to the photo library.</string>
 </dict>
 </plist>

--- a/Example/editorTest/ViewController.swift
+++ b/Example/editorTest/ViewController.swift
@@ -9,6 +9,16 @@
 import UIKit
 import iOSPhotoEditor
 
+// Here, to mimic bug: https://github.com/jonchui/photo-editor/issues/1
+extension UIImagePickerController {
+    override open var shouldAutorotate: Bool {
+        return true
+    }
+    override open var supportedInterfaceOrientations : UIInterfaceOrientationMask {
+        return .all
+    }
+}
+
 class ViewController: UIViewController {
 
     @IBOutlet weak var imageView: UIImageView!

--- a/Photo Editor/Photo Editor/PhotoEditorViewController.swift
+++ b/Photo Editor/Photo Editor/PhotoEditorViewController.swift
@@ -8,16 +8,6 @@
 
 import UIKit
 
-extension UIImagePickerController {
-    override open var shouldAutorotate: Bool {
-        return true
-    }
-    override open var supportedInterfaceOrientations : UIInterfaceOrientationMask {
-        return .all
-    }
-}
-
-
 public final class PhotoEditorViewController: UIViewController {
 
     /** holding the 2 imageViews original image and drawing & stickers */
@@ -68,6 +58,8 @@ public final class PhotoEditorViewController: UIViewController {
         if (automaticallySavePhoto) {
             continueButtonPressed(doneButton)
         }
+
+        setImageViewConstraintByImageHeight(self.image)
     }
 
     deinit {
@@ -101,6 +93,12 @@ public final class PhotoEditorViewController: UIViewController {
 
     var stickersViewController: StickersViewController!
 
+    // We need to force portrait b/c otherwise, the annotations/stickers don't save properly.
+    // See: https://github.com/jonchui/photo-editor/issues/1
+    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
+    
     //Register Custom font before we load XIB
     public override func loadView() {
         registerFont()
@@ -171,8 +169,7 @@ public final class PhotoEditorViewController: UIViewController {
 
     func setImageView(image: UIImage) {
         imageView.image = image
-        let size = image.suitableSize(widthLimit: UIScreen.main.bounds.width)
-        imageViewHeightConstraint.constant = (size?.height)!
+        setImageViewConstraintByImageHeight(image)
     }
 
     func hideToolbar(hide: Bool) {
@@ -182,10 +179,17 @@ public final class PhotoEditorViewController: UIViewController {
         bottomGradient.isHidden = hide
     }
 
-    // we need to force portrait b/c otherwise, the annotations/stickers don't save properly
-    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return .portrait
+    // MARK: private functions
+
+    // image constraint must be set every time the image view changes.
+    // TODO: should we just listen to changes to imageview? there's got to be a better way ?
+    fileprivate func setImageViewConstraintByImageHeight(_ image: UIImage?) {
+        if let image = image {
+            let size = image.suitableSize(widthLimit: UIScreen.main.bounds.width)
+            imageViewHeightConstraint.constant = (size?.height)!
+        }
     }
+
 }
 
 extension PhotoEditorViewController: ColorDelegate {

--- a/Photo Editor/Photo Editor/PhotoEditorViewController.swift
+++ b/Photo Editor/Photo Editor/PhotoEditorViewController.swift
@@ -171,6 +171,11 @@ public final class PhotoEditorViewController: UIViewController {
         bottomToolbar.isHidden = hide
         bottomGradient.isHidden = hide
     }
+
+    // we need to force portrait b/c otherwise, the annotations/stickers don't save properly
+    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
 }
 
 extension PhotoEditorViewController: ColorDelegate {

--- a/Photo Editor/Photo Editor/PhotoEditorViewController.swift
+++ b/Photo Editor/Photo Editor/PhotoEditorViewController.swift
@@ -8,6 +8,16 @@
 
 import UIKit
 
+extension UIImagePickerController {
+    override open var shouldAutorotate: Bool {
+        return true
+    }
+    override open var supportedInterfaceOrientations : UIInterfaceOrientationMask {
+        return .all
+    }
+}
+
+
 public final class PhotoEditorViewController: UIViewController {
 
     /** holding the 2 imageViews original image and drawing & stickers */

--- a/Photo Editor/Photo Editor/UIView+Image.swift
+++ b/Photo Editor/Photo Editor/UIView+Image.swift
@@ -25,14 +25,14 @@ extension UIView {
     // source: https://github.com/yackle/CLImageEditor/blob/master/OptionalImageTools/CLStickerTool/CLStickerTool.m#L179 in objective-c, converted to swift using Swiftify v1.0.6472 - https://objectivec2swift.com/
     func build(_ originalImage: UIImage, workingView: UIView) -> UIImage? {
 
-        let scale = originalImage.size.width / workingView.bounds.width
-        let layer = workingView.layer
+        let xScale = originalImage.size.width / workingView.bounds.width
+        let yScale = originalImage.size.height / workingView.bounds.height
 
         var retImage : UIImage?
         UIGraphicsBeginImageContextWithOptions(originalImage.size, false, originalImage.scale)
-        originalImage.draw(at: CGPoint.zero)
-        UIGraphicsGetCurrentContext()?.scaleBy(x: scale, y: scale)
-        layer.render(in: UIGraphicsGetCurrentContext()!)
+//        originalImage.draw(at: CGPoint.zero)
+        UIGraphicsGetCurrentContext()?.scaleBy(x: xScale, y: yScale)
+        workingView.layer.render(in: UIGraphicsGetCurrentContext()!)
         retImage = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
 


### PR DESCRIPTION
Turns out original project used a constraint every time the `image` was set and would change the imageview height. 

i just refactored it out and call it on viewDidAppear - though i guess, we COULD just move it to viewDidAppear in general.... hm, wdyt @onlyrandomness ?

I remember coming up against this before w/ our older EditorImageVC and needing to have the functionality to resize an ImageView whenever it's image gets changed:

I found a few answers but they all required a lot of hacky code on imageview: ex. https://stackoverflow.com/questions/19359519/resizing-imageview-as-the-uiviewcontentmodescaleaspectfit-content

anyways, here's a GIF of fix:

![](http://recordit.co/jdOX5BkMGd.gif)